### PR TITLE
Mute/fade for AUX and FX bus

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -1,11 +1,11 @@
 **Soundcraft Ui12 / Ui16 / Ui24**
 
-This Module controls the Soundcraft Ui series go over to [Soundcraft](https://www.soundcraft.com/en/product_families/ui-series)
-to get additional information about the different consoles and their capabilities.
+This module controls the Soundcraft Ui series.
+Go over to [Soundcraft](https://www.soundcraft.com/en/product_families/ui-series) to get additional information about the different consoles and their capabilities.
 
 We support the following actions:
 
 Console Function   | What it does
 -------------------|---------------
-Set Mute / Unmulte | Mute or Unmute the selected input, output, player, fx or subgroup channel. Be aware of your device's capabilities.
-Set Fader Levels   | Sets the level of a fader for the selected (in/out/player/fx/sub) channel.
+Set Mute / Unmute | Mute or Unmute any input, output, player, FX, sub group or VCA channel. The target can be master, AUX or FX buses. Be aware of your device's capabilities.
+Set Fader Levels  | Set the level of a fader for a channel

--- a/index.js
+++ b/index.js
@@ -77,6 +77,12 @@ class instance extends instance_skel {
 			{ id: 'v', label: 'VCA' },
 		];
 
+		this.BUS_TYPE = [
+			{ id: 'master', label: 'Master' },
+			{ id: 'aux', label: 'AUX' },
+			{ id: 'fx', label: 'FX Send' },
+		]
+
 		this.reconnecting = null;
 		this.actions(system);
 	}
@@ -90,19 +96,40 @@ class instance extends instance_skel {
 		this.setActions({
 			'mute': {
 				label: 'Set Mute',
-				options: [{
+				options: [
+					{
 						type: 	 'dropdown',
-						label: 	 'Type',
+						label: 	 'Channel Type',
 						id: 	 'type',
 						choices: this.FADER_TYPE,
 						default: 'i'
 					},
 					{
-						type:	 'textinput',
-						label:	 'Channel Number of Input, Line Input, Player, FX, Sub Group or AUX Group',
+						type:	 'number',
+						label:	 'Channel Number',
+						tooltip: 'Channel Number of Input, Line Input, Player, FX, Sub Group or AUX Group',
 						id:    	 'channel',
-						regex:	 this.REGEX_NUMBER,
-						default: '1'
+						default: 1,
+						min: 1,
+						max: 24,
+						step: 1,
+						required: true
+					},
+					{
+						type:	 'dropdown',
+						label:	 'Bus Type',
+						id:    	 'bustype',
+						choices: this.BUS_TYPE,
+						default: 'master'
+					},
+					{
+						type:	 'number',
+						label:	 'Bus Number',
+						id:    	 'bus',
+						default: 1,
+						min: 1,
+						max: 24,
+						step: 1
 					},
 					{
 						type:   'dropdown',
@@ -127,11 +154,31 @@ class instance extends instance_skel {
 						default: 'i'
 					},
 					{
-						type:	'textinput',
-						label:	'Channel Number of Input, Line Input, Player, FX, Sub Group or AUX Group',
-						id:    	'channel',
-						regex:	this.REGEX_NUMBER,
-						default: '1'
+						type:	 'number',
+						label:	 'Channel Number',
+						tooltip: 'Channel Number of Input, Line Input, Player, FX, Sub Group or AUX Group',
+						id:    	 'channel',
+						default: 1,
+						min: 1,
+						max: 24,
+						step: 1,
+						required: true
+					},
+					{
+						type:	 'dropdown',
+						label:	 'Bus Type',
+						id:    	 'bustype',
+						choices: this.BUS_TYPE,
+						default: 'master'
+					},
+					{
+						type:	 'number',
+						label:	 'Bus Number',
+						id:    	 'bus',
+						default: 1,
+						min: 1,
+						max: 24,
+						step: 1
 					},
 					{
 						type: 	 'dropdown',
@@ -155,10 +202,10 @@ class instance extends instance_skel {
 
 		switch (action.action) {
 			case 'mute':
-				this.mute(opt.type, opt.channel, opt.mute);
+				this.mute(opt.type, opt.channel, opt.bustype, opt.bus, opt.mute);
 				break;
 			case 'fade':
-				this.fade(opt.type, opt.channel, opt.level);
+				this.fade(opt.type, opt.channel, opt.bustype, opt.bus, opt.level);
 
 		}
 	}
@@ -186,13 +233,13 @@ class instance extends instance_skel {
 	 */
 	init() {
 		this.status(this.STATUS_UNKNOWN);
-		if(this.config.host) {
+		if (this.config.host) {
 			this.connect();
 		}
 	}
 
 	/**
-	 * Process an updated configuration array.
+	 * Process an updated configuration array
 	 *
 	 * @param {Object} config - the new configuration
 	 * @access public
@@ -201,8 +248,7 @@ class instance extends instance_skel {
 	updateConfig(config) {
 		var resetConnection = false;
 
-		if (this.config.host != config.host)
-		{
+		if (this.config.host != config.host) {
 			resetConnection = true;
 		}
 
@@ -221,14 +267,14 @@ class instance extends instance_skel {
 	 */
 	connect() {
 		this.log('info', 'Attempting to connect to switcher');
-		if(this.reconnecting) { // existing reconnect attempt
+		if (this.reconnecting) { // existing reconnect attempt
 			clearTimeout(this.reconnecting);
 			this.reconnecting = null;
 		}
-		if(this.socket && this.socket.connected) {
+		if (this.socket && this.socket.connected) {
 			this.disconnect();
 		}
-		if(!this.config.host) {
+		if (!this.config.host) {
 			return;
 		}
 
@@ -281,30 +327,51 @@ class instance extends instance_skel {
 	}
 
 	/**
+	 * Determine the internal identifier of the channel, according to the given channel, bus number and bus type
+	 * @param {number} channel
+	 * @param {string} bustype 
+	 * @param {number} bus 
+	 */
+	getFullChannelId(channel, bustype, bus = 1) {
+		switch (bustype) {
+			case 'aux': return `${channel - 1}.aux.${bus - 1}`;
+			case 'fx': return `${channel - 1}.fx.${bus - 1}`;
+			case 'master':
+			default:
+				return channel - 1;
+		}
+	}
+
+	/**
 	 * Mute or unmute a defined channel (input/output/fx/aux/etc.)
-	 * @param {char} type 
-	 * @param {int} channel 
+	 * @param {string} type 
+	 * @param {number} channel 
+	 * @param {string} bustype 
+	 * @param {number} bus 
 	 * @param {any} value 
 	 */
-	mute(type, channel, value) {
-		var cmd = "3:::SETD^{type}.{channel}.mute^{flag}"
-			.replace("{type}", type)
-			.replace("{channel}", channel - 1)
-			.replace("{flag}", value);
+	mute(type, channel, bustype, bus, value) {
+		const channelId = this.getFullChannelId(channel, bustype, bus);
+		const cmd = `3:::SETD^${type}.${channelId}.mute^${value}`;
 		this.sendCommand(cmd);
 	}
 
 	/**
 	 * Set the level for a defined channel (input/output/fx/aux/etc.)
-	 * @param {char} type 
-	 * @param {int} channel 
+	 * @param {string} type 
+	 * @param {number} channel
+	 * @param {string} bustype 
+	 * @param {number} bus 
 	 * @param {any} value 
 	 */
-	fade(type, channel, value) {
-		var cmd = "3:::SETD^{type}.{channel}.mix^{flag}"
-			.replace("{type}", type)
-			.replace("{channel}", channel - 1)
-			.replace("{flag}", value);
+	fade(type, channel, bustype, bus, value) {
+		const commandNames = {
+			master: 'mix',
+			aux: 'value',
+			fx: 'value'
+		};
+		const channelId = this.getFullChannelId(channel, bustype, bus);
+		const cmd = `3:::SETD^${type}.${channelId}.${commandNames[bustype]}^${value}`;
 		this.sendCommand(cmd);
 	}
 
@@ -312,7 +379,7 @@ class instance extends instance_skel {
 	 * Send keep alive to the device to prevent disconnects
 	 */
 	keepAlive() {
-		this.sendCommand(`3:::ALIVE`);
+		this.sendCommand('3:::ALIVE');
 	}
 
 	/**
@@ -321,7 +388,7 @@ class instance extends instance_skel {
 	 * @since 1.0.0
 	 */
 	sendCommand(command) {
-		if(!this.socket || !this.socket.connected) {
+		if (!this.socket || !this.socket.connected) {
 			this.log('warning', 'Switcher not connected');
 			this.reconnect.bind(this, true);
 			return;
@@ -331,19 +398,19 @@ class instance extends instance_skel {
 	}
 
 	/**
-	 * Disconccect from device
+	 * Disconnect from device
 	 * @since 1.0.0
 	 */
 	disconnect() {
 		this.log('info', 'Disconnecting from switcher');
 		this.status(this.STATUS_ERROR);
-		if(this.socket && this.socket.connected) {
+		if (this.socket && this.socket.connected) {
 			this.socket.close();
 		}
 	}
 
 	/**
-	 * Ends session if disconnected
+	 * End session if disconnected
 	 * @since 1.0.0
 	 */
 	destroy() {

--- a/index.js
+++ b/index.js
@@ -72,8 +72,9 @@ class instance extends instance_skel {
 			{ id: 'l', label: 'Line Input' },
 			{ id: 'p', label: 'Player' },
 			{ id: 'f', label: 'FX' },
-			{ id: 's', label: 'Sub Groups' },
+			{ id: 's', label: 'Sub Group' },
 			{ id: 'a', label: 'AUX Output' },
+			{ id: 'v', label: 'VCA' },
 		];
 
 		this.reconnecting = null;

--- a/package.json
+++ b/package.json
@@ -13,11 +13,14 @@
 		"UI24"
 	],
 	"shortname": "ui",
-	"description": "Module for controling the Soundcraft Ui consoles",
+	"description": "Module for controlling the Soundcraft Ui consoles",
 	"main": "index.js",
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1"
 	},
 	"author": "Christian Himmler <christian@himmlers.de>",
+	"contributors": [
+		"Ferdinand Malcher <ferdinand@malcher.media>"
+	],
 	"license": "MIT"
 }


### PR DESCRIPTION
Setting fader levels and muting channels was only possible for the master bus.
This PR extends the functionality: Fader levels and mute can now be set on AUX and FX buses as well.
For this, the action has two new options now:
- bus type (master/aux/fx)
- the bus number

The bus number must only be provided if the bus is not master.
This PR also brings some minor code formatting changes.


![Screen Shot 2020-10-15 at 17 29 30](https://user-images.githubusercontent.com/1683147/96152098-714fa000-0f0c-11eb-8264-368a94fefde1.png)


### Open topics
- Is there a way to conditionally hide action option fields? If yes, we should hide the "bus number" field if "master" is selected as bus type.
- Is this a breaking change? IMO it will be compatible with the current state.