### PR TITLE
feat: add fader level percentage variables

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,7 @@ import { type SomeCompanionConfigField, Regex } from '@companion-module/base'
 export interface UiConfig {
 	host: string
 	enableFaderLevelVars?: boolean
+	enableFaderLevelVarsPct?: boolean
 	enablePanVars?: boolean
 }
 
@@ -26,7 +27,14 @@ export const instanceConfigFields: SomeCompanionConfigField[] = [
 	{
 		type: 'checkbox',
 		id: 'enableFaderLevelVars',
-		label: 'Enable Fader Level variables',
+		label: 'Enable Fader Level variables (dB)',
+		width: 12,
+		default: false,
+	},
+	{
+		type: 'checkbox',
+		id: 'enableFaderLevelVarsPct',
+		label: 'Enable Fader Level variables (%)',
 		width: 12,
 		default: false,
 	},

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -31,6 +31,11 @@ export function mapInfinityToNumber(value: number): number {
 	return value === Number.NEGATIVE_INFINITY ? -100 : value
 }
 
+/** Convert internal 0..1 value to percent range (0..100) */
+export function convertLinearValueToPercent(linearValue: number): number {
+	return Math.round(linearValue * 100)
+}
+
 /** Convert PAN value 0..1 to string representation (L 100 .. C .. R 100) */
 /*export function convertPanLinearValueToString(value: number): string {
 	if (value === 0) {

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -3,7 +3,7 @@ import { playerTimeToString, type SoundcraftUI } from 'soundcraft-ui-connection'
 import { firstValueFrom, map, Observable, share } from 'rxjs'
 
 import type { UiVariablesStore } from './variables-store.js'
-import { mapInfinityToNumber, convertLinearValueToPan } from './utils/utils.js'
+import { mapInfinityToNumber, convertLinearValueToPan, convertLinearValueToPercent } from './utils/utils.js'
 import type { UiConfig } from './config.js'
 
 export async function createVariables(
@@ -26,6 +26,13 @@ export async function createVariables(
 		{ id: 'm_level', name: 'Master: Fader Level (dB)' },
 		conn.master.faderLevelDB$.pipe(map((v) => mapInfinityToNumber(v))),
 	)
+
+	if (config.enableFaderLevelVarsPct) {
+		addVar(
+			{ id: 'm_level_pct', name: 'Master: Fader Level (%)' },
+			conn.master.faderLevel$.pipe(map((lin) => convertLinearValueToPercent(lin))),
+		)
+	}
 
 	/****** Shows ******/
 	addVar({ id: 'show_show', name: 'Shows: Current Show' }, conn.shows.currentShow$)
@@ -81,6 +88,10 @@ export async function createVariables(
 	/****** Input Channels ******/
 	for (let i = 1; i <= capabilities.input; i++) {
 		const channel = conn.master.input(i)
+
+		// Channel Name
+		addVar({ id: `m_input${i}_name`, name: `[Master Bus] Input ${i}: Name` }, channel.name$)
+
 		// Fader Level
 		if (config.enableFaderLevelVars) {
 			addVar(
@@ -89,8 +100,12 @@ export async function createVariables(
 			)
 		}
 
-		// Channel Name
-		addVar({ id: `m_input${i}_name`, name: `[Master Bus] Input ${i}: Name` }, channel.name$)
+		if (config.enableFaderLevelVarsPct) {
+			addVar(
+				{ id: `m_input${i}_level_pct`, name: `[Master Bus] Input ${i}: Fader Level (%)` },
+				channel.faderLevel$.pipe(map((lin) => convertLinearValueToPercent(lin))),
+			)
+		}
 
 		// PAN
 		if (config.enablePanVars) {
@@ -104,6 +119,10 @@ export async function createVariables(
 	/****** Line Channels ******/
 	for (let i = 1; i <= capabilities.line; i++) {
 		const channel = conn.master.line(i)
+
+		// Channel Name
+		addVar({ id: `m_line${i}_name`, name: `[Master Bus] Line ${i}: Name` }, channel.name$)
+
 		// Fader Level
 		if (config.enableFaderLevelVars) {
 			addVar(
@@ -112,8 +131,12 @@ export async function createVariables(
 			)
 		}
 
-		// Channel Name
-		addVar({ id: `m_line${i}_name`, name: `[Master Bus] Line ${i}: Name` }, channel.name$)
+		if (config.enableFaderLevelVarsPct) {
+			addVar(
+				{ id: `m_line${i}_level_pct`, name: `[Master Bus] Line ${i}: Fader Level (%)` },
+				channel.faderLevel$.pipe(map((lin) => convertLinearValueToPercent(lin))),
+			)
+		}
 
 		// PAN
 		if (config.enablePanVars) {
@@ -127,6 +150,10 @@ export async function createVariables(
 	/****** Player Channels ******/
 	for (let i = 1; i <= capabilities.player; i++) {
 		const channel = conn.master.player(i)
+
+		// Channel Name
+		addVar({ id: `m_player${i}_name`, name: `[Master Bus] Player ${i}: Name` }, channel.name$)
+
 		// Fader Level
 		if (config.enableFaderLevelVars) {
 			addVar(
@@ -135,8 +162,12 @@ export async function createVariables(
 			)
 		}
 
-		// Channel Name
-		addVar({ id: `m_player${i}_name`, name: `[Master Bus] Player ${i}: Name` }, channel.name$)
+		if (config.enableFaderLevelVarsPct) {
+			addVar(
+				{ id: `m_player${i}_level_pct`, name: `[Master Bus] Player ${i}: Fader Level (%)` },
+				channel.faderLevel$.pipe(map((lin) => convertLinearValueToPercent(lin))),
+			)
+		}
 
 		// PAN
 		if (config.enablePanVars) {
@@ -150,6 +181,10 @@ export async function createVariables(
 	/****** Subgroups ******/
 	for (let i = 1; i <= capabilities.sub; i++) {
 		const channel = conn.master.sub(i)
+
+		// Channel Name
+		addVar({ id: `m_sub${i}_name`, name: `[Master Bus] Subgroup ${i}: Name` }, channel.name$)
+
 		// Fader Level
 		if (config.enableFaderLevelVars) {
 			addVar(
@@ -158,8 +193,12 @@ export async function createVariables(
 			)
 		}
 
-		// Channel Name
-		addVar({ id: `m_sub${i}_name`, name: `[Master Bus] Subgroup ${i}: Name` }, channel.name$)
+		if (config.enableFaderLevelVarsPct) {
+			addVar(
+				{ id: `m_sub${i}_level_pct`, name: `[Master Bus] Subgroup ${i}: Fader Level (%)` },
+				channel.faderLevel$.pipe(map((lin) => convertLinearValueToPercent(lin))),
+			)
+		}
 
 		// PAN
 		if (config.enablePanVars) {
@@ -172,6 +211,9 @@ export async function createVariables(
 
 	/****** VCA ******/
 	for (let i = 1; i <= capabilities.vca; i++) {
+		// Channel Name
+		addVar({ id: `m_vca${i}_name`, name: `[Master Bus] VCA ${i}: Name` }, conn.master.vca(i).name$)
+
 		// Fader Level
 		if (config.enableFaderLevelVars) {
 			addVar(
@@ -180,13 +222,21 @@ export async function createVariables(
 			)
 		}
 
-		// Channel Name
-		addVar({ id: `m_vca${i}_name`, name: `[Master Bus] VCA ${i}: Name` }, conn.master.vca(i).name$)
+		if (config.enableFaderLevelVarsPct) {
+			addVar(
+				{ id: `m_vca${i}_level_pct`, name: `[Master Bus] VCA ${i}: Fader Level (%)` },
+				conn.master.vca(i).faderLevel$.pipe(map((lin) => convertLinearValueToPercent(lin))),
+			)
+		}
 	}
 
 	/****** FX Channels/Buses ******/
 	for (let fi = 1; fi <= capabilities.fx; fi++) {
 		const fx = conn.master.fx(fi)
+
+		// Channel Name
+		addVar({ id: `m_fx${fi}_name`, name: `[Master Bus] FX ${fi}: Name` }, fx.name$)
+
 		// Fader Level
 		if (config.enableFaderLevelVars) {
 			addVar(
@@ -195,8 +245,12 @@ export async function createVariables(
 			)
 		}
 
-		// Channel Name
-		addVar({ id: `m_fx${fi}_name`, name: `[Master Bus] FX ${fi}: Name` }, fx.name$)
+		if (config.enableFaderLevelVarsPct) {
+			addVar(
+				{ id: `m_fx${fi}_level_pct`, name: `[Master Bus] FX ${fi}: Fader Level (%)` },
+				fx.faderLevel$.pipe(map((lin) => convertLinearValueToPercent(lin))),
+			)
+		}
 
 		// PAN
 		if (config.enablePanVars) {
@@ -207,38 +261,79 @@ export async function createVariables(
 		}
 
 		// FX BUS CHANNELS
-		if (config.enableFaderLevelVars) {
-			const fxBus = conn.fx(fi)
-			// FX: Input Channels
-			for (let i = 1; i <= capabilities.input; i++) {
-				const channel = fxBus.input(i)
+		const fxBus = conn.fx(fi)
+		// FX: Input Channels
+		for (let i = 1; i <= capabilities.input; i++) {
+			const channel = fxBus.input(i)
+			// Fader Level
+			if (config.enableFaderLevelVars) {
 				addVar(
 					{ id: `fx${fi}_input${i}_level`, name: `[FX ${fi}] Input ${i}: Fader Level (dB)` },
 					channel.faderLevelDB$.pipe(map((v) => mapInfinityToNumber(v))),
 				)
 			}
-			// FX: Line Channels
-			for (let i = 1; i <= capabilities.line; i++) {
-				const channel = fxBus.line(i)
+
+			if (config.enableFaderLevelVarsPct) {
+				addVar(
+					{ id: `fx${fi}_input${i}_level_pct`, name: `[FX ${fi}] Input ${i}: Fader Level (%)` },
+					channel.faderLevel$.pipe(map((lin) => convertLinearValueToPercent(lin))),
+				)
+			}
+		}
+
+		// FX: Line Channels
+		for (let i = 1; i <= capabilities.line; i++) {
+			const channel = fxBus.line(i)
+			// Fader Level
+			if (config.enableFaderLevelVars) {
 				addVar(
 					{ id: `fx${fi}_line${i}_level`, name: `[FX ${fi}] Line ${i}: Fader Level (dB)` },
 					channel.faderLevelDB$.pipe(map((v) => mapInfinityToNumber(v))),
 				)
 			}
-			// FX: Player Channels
-			for (let i = 1; i <= capabilities.player; i++) {
-				const channel = fxBus.player(i)
+
+			if (config.enableFaderLevelVarsPct) {
+				addVar(
+					{ id: `fx${fi}_line${i}_level_pct`, name: `[FX ${fi}] Line ${i}: Fader Level (%)` },
+					channel.faderLevel$.pipe(map((lin) => convertLinearValueToPercent(lin))),
+				)
+			}
+		}
+
+		// FX: Player Channels
+		for (let i = 1; i <= capabilities.player; i++) {
+			const channel = fxBus.player(i)
+			// Fader Level
+			if (config.enableFaderLevelVars) {
 				addVar(
 					{ id: `fx${fi}_player${i}_level`, name: `[FX ${fi}] Player ${i}: Fader Level (dB)` },
 					channel.faderLevelDB$.pipe(map((v) => mapInfinityToNumber(v))),
 				)
 			}
-			// FX: Subgroups
-			for (let i = 1; i <= capabilities.sub; i++) {
-				const channel = fxBus.sub(i)
+
+			if (config.enableFaderLevelVarsPct) {
+				addVar(
+					{ id: `fx${fi}_player${i}_level_pct`, name: `[FX ${fi}] Player ${i}: Fader Level (%)` },
+					channel.faderLevel$.pipe(map((lin) => convertLinearValueToPercent(lin))),
+				)
+			}
+		}
+
+		// FX: Subgroups
+		for (let i = 1; i <= capabilities.sub; i++) {
+			const channel = fxBus.sub(i)
+			// Fader Level
+			if (config.enableFaderLevelVars) {
 				addVar(
 					{ id: `fx${fi}_sub${i}_level`, name: `[FX ${fi}] Subgroup ${i}: Fader Level (dB)` },
 					channel.faderLevelDB$.pipe(map((v) => mapInfinityToNumber(v))),
+				)
+			}
+
+			if (config.enableFaderLevelVarsPct) {
+				addVar(
+					{ id: `fx${fi}_sub${i}_level_pct`, name: `[FX ${fi}] Subgroup ${i}: Fader Level (%)` },
+					channel.faderLevel$.pipe(map((lin) => convertLinearValueToPercent(lin))),
 				)
 			}
 		}
@@ -247,6 +342,10 @@ export async function createVariables(
 	/****** AUX channels/buses ******/
 	for (let ai = 1; ai <= capabilities.aux; ai++) {
 		const aux = conn.master.aux(ai)
+
+		// Channel Name
+		addVar({ id: `m_aux${ai}_name`, name: `[Master Bus] AUX ${ai}: Name` }, aux.name$)
+
 		// Fader Level
 		if (config.enableFaderLevelVars) {
 			addVar(
@@ -255,8 +354,12 @@ export async function createVariables(
 			)
 		}
 
-		// Channel Name
-		addVar({ id: `m_aux${ai}_name`, name: `[Master Bus] AUX ${ai}: Name` }, aux.name$)
+		if (config.enableFaderLevelVarsPct) {
+			addVar(
+				{ id: `m_aux${ai}_level_pct`, name: `[Master Bus] AUX ${ai}: Fader Level (%)` },
+				aux.faderLevel$.pipe(map((lin) => convertLinearValueToPercent(lin))),
+			)
+		}
 
 		// AUX BUS CHANNELS
 		const auxBus = conn.aux(ai)
@@ -268,6 +371,13 @@ export async function createVariables(
 				addVar(
 					{ id: `aux${ai}_input${i}_level`, name: `[AUX ${ai}] Input ${i}: Fader Level (dB)` },
 					channel.faderLevelDB$.pipe(map((v) => mapInfinityToNumber(v))),
+				)
+			}
+
+			if (config.enableFaderLevelVarsPct) {
+				addVar(
+					{ id: `aux${ai}_input${i}_level_pct`, name: `[AUX ${ai}] Input ${i}: Fader Level (%)` },
+					channel.faderLevel$.pipe(map((lin) => convertLinearValueToPercent(lin))),
 				)
 			}
 
@@ -291,6 +401,13 @@ export async function createVariables(
 				)
 			}
 
+			if (config.enableFaderLevelVarsPct) {
+				addVar(
+					{ id: `aux${ai}_line${i}_level_pct`, name: `[AUX ${ai}] Line ${i}: Fader Level (%)` },
+					channel.faderLevel$.pipe(map((lin) => convertLinearValueToPercent(lin))),
+				)
+			}
+
 			// PAN
 			if (config.enablePanVars) {
 				addVar(
@@ -311,6 +428,13 @@ export async function createVariables(
 				)
 			}
 
+			if (config.enableFaderLevelVarsPct) {
+				addVar(
+					{ id: `aux${ai}_player${i}_level_pct`, name: `[AUX ${ai}] Player ${i}: Fader Level (%)` },
+					channel.faderLevel$.pipe(map((lin) => convertLinearValueToPercent(lin))),
+				)
+			}
+
 			// PAN
 			if (config.enablePanVars) {
 				addVar(
@@ -328,6 +452,13 @@ export async function createVariables(
 				addVar(
 					{ id: `aux${ai}_fx${i}_level`, name: `[AUX ${ai}] FX ${i}: Fader Level (dB)` },
 					channel.faderLevelDB$.pipe(map((v) => mapInfinityToNumber(v))),
+				)
+			}
+
+			if (config.enableFaderLevelVarsPct) {
+				addVar(
+					{ id: `aux${ai}_fx${i}_level_pct`, name: `[AUX ${ai}] FX ${i}: Fader Level (%)` },
+					channel.faderLevel$.pipe(map((lin) => convertLinearValueToPercent(lin))),
 				)
 			}
 


### PR DESCRIPTION
Add optional percentage-based fader level variables for all channel types, controlled by new `enableFaderLevelVarsPct` config option.

related to #117 