### PR TITLE
feat(actions): support variables in fader and pan inputs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { GetActionsList } from './actions.js'
 import { instanceConfigFields, type UiConfig } from './config.js'
 import { GetFeedbacksList } from './feedback.js'
 import { UiFeedbackStore } from './feedback-store.js'
-import { upgradeLegacyFeedbackToBoolean, upgradeV2x0x0 } from './upgrades.js'
+import { upgradeLegacyFeedbackToBoolean, upgradeNumberInputsToText, upgradeV2x0x0 } from './upgrades.js'
 import { createPresets } from './presets.js'
 import { createVariables } from './variables.js'
 import { UiVariablesStore } from './variables-store.js'
@@ -137,4 +137,4 @@ class SoundcraftUiInstance extends InstanceBase<UiConfig> {
 	}
 }
 
-runEntrypoint(SoundcraftUiInstance, [upgradeV2x0x0, upgradeLegacyFeedbackToBoolean])
+runEntrypoint(SoundcraftUiInstance, [upgradeV2x0x0, upgradeLegacyFeedbackToBoolean, upgradeNumberInputsToText])

--- a/src/upgrades.ts
+++ b/src/upgrades.ts
@@ -1,5 +1,40 @@
 import { type CompanionStaticUpgradeScript, CreateConvertToBooleanFeedbackUpgradeScript } from '@companion-module/base'
 import { FeedbackId } from './feedback.js'
+import { ActionId } from './actions.js'
+
+/** Convert actions with numeric `value` option to string */
+export const upgradeNumberInputsToText: CompanionStaticUpgradeScript<unknown> = function (_context, props) {
+	const upgradableActionsIds: string[] = [
+		ActionId.SetMasterValue,
+		ActionId.SetMasterChannelValue,
+		ActionId.SetAuxChannelValue,
+		ActionId.SetVolumeBusValue,
+		ActionId.SetFxChannelValue,
+		ActionId.FadeMaster,
+		ActionId.FadeMasterChannel,
+		ActionId.FadeAuxChannel,
+		ActionId.FadeFxChannel,
+		ActionId.SetMasterChannelPan,
+		ActionId.SetAuxChannelPan,
+	]
+
+	const result = {
+		updatedConfig: null,
+		updatedFeedbacks: [],
+		updatedActions: props.actions
+			.filter((action) => upgradableActionsIds.includes(action.actionId))
+			.filter((action) => Object.hasOwn(action.options, 'value') && typeof action.options.value !== 'string')
+			.map((action) => ({
+				...action,
+				options: {
+					...action.options,
+					value: action.options.value?.toString(),
+				},
+			})),
+	}
+
+	return result
+}
 
 export const upgradeLegacyFeedbackToBoolean = CreateConvertToBooleanFeedbackUpgradeScript({
 	[FeedbackId.MuteMasterChannel]: true,

--- a/src/utils/input-utils.ts
+++ b/src/utils/input-utils.ts
@@ -1,6 +1,7 @@
 import type {
 	CompanionInputFieldDropdown,
 	CompanionInputFieldNumber,
+	CompanionInputFieldTextInput,
 	DropdownChoice,
 	SomeCompanionActionInputField,
 } from '@companion-module/base'
@@ -154,17 +155,13 @@ export const OPTIONS = {
 		id: 'solo',
 		...CHOICES.onofftoggleDropdown,
 	} satisfies CompanionInputFieldDropdown,
-	faderValuesSlider: {
-		type: 'number',
+	faderValueDBInput: {
+		type: 'textinput',
 		label: 'Fader Level dB (-100 = -∞)',
 		id: 'value',
-		range: true,
 		required: true,
-		default: 0,
-		step: 0.1,
-		min: -100,
-		max: 10,
-	} satisfies CompanionInputFieldNumber,
+		useVariables: true,
+	} satisfies CompanionInputFieldTextInput,
 	prepostDropdown: {
 		type: 'dropdown',
 		label: 'PRE/POST',
@@ -188,7 +185,7 @@ export const OPTIONS = {
 		],
 		default: Easings.Linear,
 	} satisfies CompanionInputFieldDropdown,
-	fadeTimeField: {
+	fadeTimeInput: {
 		type: 'number',
 		label: 'Fade time (ms)',
 		id: 'fadeTime',
@@ -196,7 +193,7 @@ export const OPTIONS = {
 		max: 60000,
 		default: 2000,
 	} satisfies CompanionInputFieldNumber,
-	faderChangeField: {
+	faderChangeInput: {
 		type: 'number',
 		label: 'Change value (dB)',
 		id: 'value',
@@ -226,7 +223,7 @@ export const OPTIONS = {
 		],
 		default: 'both',
 	} satisfies CompanionInputFieldDropdown,
-	delayTimeField: (min: number, max: number): CompanionInputFieldNumber => {
+	delayTimeInput: (min: number, max: number): CompanionInputFieldNumber => {
 		return {
 			type: 'number',
 			label: 'Delay time (ms)',
@@ -236,18 +233,14 @@ export const OPTIONS = {
 			default: 0,
 		}
 	},
-	panValueSlider: {
-		type: 'number',
+	panValueInput: {
+		type: 'textinput',
 		label: 'Pan (L = -100, Center = 0, R = 100)',
 		id: 'value',
-		range: true,
 		required: true,
-		default: 0,
-		step: 1,
-		min: -100,
-		max: 100,
-	} satisfies CompanionInputFieldNumber,
-	panChangeField: {
+		useVariables: true,
+	} satisfies CompanionInputFieldTextInput,
+	panChangeInput: {
 		type: 'number',
 		label: 'Change value',
 		id: 'value',
@@ -265,7 +258,7 @@ export const OPTION_SETS = {
 	masterChannel: [OPTIONS.masterChannelTypeDropdown, OPTIONS.channelNumberField],
 	auxChannel: [OPTIONS.busNumberField, OPTIONS.auxChannelTypeDropdown, OPTIONS.channelNumberField],
 	fxChannel: [OPTIONS.busNumberField, OPTIONS.fxChannelTypeDropdown, OPTIONS.channelNumberField],
-	fadeTransition: [OPTIONS.faderValuesSlider, OPTIONS.fadeTimeField, OPTIONS.easingsDropdown],
+	fadeTransition: [OPTIONS.faderValueDBInput, OPTIONS.fadeTimeInput, OPTIONS.easingsDropdown],
 	delayableMasterChannel: (min: number, max: number): SomeCompanionActionInputField[] => [
 		{
 			type: 'dropdown',
@@ -274,7 +267,7 @@ export const OPTION_SETS = {
 			...CHOICES.masterDelayableChannelTypes,
 		},
 		OPTIONS.channelNumberField,
-		OPTIONS.delayTimeField(min, max),
+		OPTIONS.delayTimeInput(min, max),
 	],
 	pannableMasterChannel: [
 		{

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -2,6 +2,10 @@ import { type ChannelType } from 'soundcraft-ui-connection'
 
 import { FADER_TYPES } from './input-utils.js'
 
+export function isValidNumber(value: number): boolean {
+	return Number.isFinite(value)
+}
+
 export function intToBool(value: number): boolean {
 	return value === 1
 }


### PR DESCRIPTION
> [!IMPORTANT]
> most possibly a `wontfix` due to the recent changes in https://github.com/bitfocus/companion/pull/3923


Convert fader level and pan value inputs from numeric sliders to text inputs with variable support. Add isValidNumber guard to all affected actions and upgrade script to migrate existing configurations.

The following actions now accept text input for fader values:

- SetMasterValue
- SetMasterChannelValue
- SetAuxChannelValue
- SetVolumeBusValue
- SetFxChannelValue
- FadeMaster
- FadeMasterChannel
- FadeAuxChannel
- FadeFxChannel
- SetMasterChannelPan
- SetAuxChannelPan