### PR TITLE
feat: allow expressions for channel, bus, and FX numbers

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -744,7 +744,6 @@ export function GetActionsList(conn: SoundcraftUI): CompanionActionDefinitions<U
 					],
 					default: [2, 3, 4],
 					minSelection: 1,
-					disableAutoExpression: true,
 				},
 				{
 					type: 'number',
@@ -778,7 +777,6 @@ export function GetActionsList(conn: SoundcraftUI): CompanionActionDefinitions<U
 						{ id: 4, label: 'FX 4' },
 					],
 					default: 1,
-					disableAutoExpression: true,
 				},
 				{
 					type: 'dropdown',
@@ -793,7 +791,6 @@ export function GetActionsList(conn: SoundcraftUI): CompanionActionDefinitions<U
 						{ id: 6, label: '6' },
 					],
 					default: 1,
-					disableAutoExpression: true,
 				},
 				{
 					type: 'number',

--- a/src/utils/input-utils.ts
+++ b/src/utils/input-utils.ts
@@ -118,7 +118,6 @@ export const OPTIONS = {
 		min: 1,
 		max: 10,
 		default: 1,
-		disableAutoExpression: true,
 	} satisfies CompanionInputFieldNumber<'bus'>,
 	channelNumberField: {
 		type: 'number',
@@ -127,7 +126,6 @@ export const OPTIONS = {
 		min: 1,
 		max: 24,
 		default: 1,
-		disableAutoExpression: true,
 	} satisfies CompanionInputFieldNumber<'channel'>,
 	hwChannelNumberField: {
 		type: 'number',
@@ -136,7 +134,6 @@ export const OPTIONS = {
 		min: 1,
 		max: 20,
 		default: 1,
-		disableAutoExpression: true,
 	} satisfies CompanionInputFieldNumber<'hwchannel'>,
 	muteDropdown: {
 		type: 'dropdown',


### PR DESCRIPTION
Enable Companion expressions on channel numbers, bus numbers, HW channel numbers, and FX/parameter number selectors in actions and feedbacks. Semantic dropdowns (channel types, modes, states) remain value-only.